### PR TITLE
Usunięto nieaktualne strony, więcej w komentarzu.

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
                                     Narzędzia
                                 </p>
                                 <p class="dropdown-item-description">
-                                    AKTUALIZACJA: 14.05.2021
+                                    AKTUALIZACJA: 27.06.2021
                                 </p>
                             </div>
                         </a>
@@ -130,7 +130,7 @@
                                     Bajki/Kreskówki
                                 </p>
                                 <p class="dropdown-item-description">
-                                    AKTUALIZACJA: 26.04.2021
+                                    AKTUALIZACJA: 27.06.2021
                                 </p>
                             </div>
                         </a>
@@ -283,7 +283,7 @@
                                     Sport online
                                 </p>
                                 <p class="dropdown-item-description">
-                                    AKTUALIZACJA: 26.06.2021
+                                    AKTUALIZACJA: 27.06.2021
                                 </p>
                             </div>
                         </a>
@@ -309,7 +309,7 @@
                                     eBooki/AudioBooki
                                 </p>
                                 <p class="dropdown-item-description">
-                                    AKTUALIZACJA: 27.05.2021
+                                    AKTUALIZACJA: 27.06.2021
                                 </p>
                             </div>
                         </a>
@@ -558,11 +558,11 @@
                 <a href="https://qnapi.github.io/" target="_blank"
                         style="color:#A9A9A9;">qNapi.github.io</a></b> -
                 program do pobierania i automatycznego dopasowywania napisów do filmów. <br>
-                11. <b>                
+                <!-- 11. <b>                
                 <a href="https://cookmeflix.xyz/" target="_blank" style="color:#A9A9A9;">CookMeFlix.xyz</a></b>
                 -
-                parę sposobów na darmowego Netflixa. <br>
-                12. <b>                
+                parę sposobów na darmowego Netflixa. <br> -->
+                11. <b>                
                 <a href="https://www.stremio.com/" target="_blank" style="color:#A9A9A9;">Stremio.com</a></b> -
                 alternatywa dla Kodi.<br>
             </font>
@@ -579,14 +579,14 @@
             <!-- 3. <a href="http://kreskoweczki.pl" target="_blank" style="color:#A9A9A9;">Kreskoweczki.pl</a><br> -->
             3. <a href="https://www.bajkidladzieci.co.pl/index.html" target="_blank"
                 style="color:#A9A9A9;">BajkiDlaDzieci.co.pl</a></br>
-            4. <a href="https://www.cda.pl/Cinek0002/folder-glowny" target="_blank"
-                style="color:#A9A9A9;">CDA/Cinek0002</a> (hasło: Sakboy2598)</br>
-            5. <a href="https://Bajeczki.org" target="_blank" style="color:#A9A9A9;">Bajeczki.org</a></br>
-            6. <a href="https://www.boomerang-tv.pl/videos" target="_blank"
+            <!-- 4. <a href="https://www.cda.pl/Cinek0002/folder-glowny" target="_blank"
+                style="color:#A9A9A9;">CDA/Cinek0002</a> (hasło: Sakboy2598)</br -->
+            4. <a href="https://Bajeczki.org" target="_blank" style="color:#A9A9A9;">Bajeczki.org</a></br>
+            5. <a href="https://www.boomerang-tv.pl/videos" target="_blank"
                 style="color:#A9A9A9;">Boomerang-TV.pl</a></br>
-            7. <a href="https://www.cartoonnetwork.pl/filmy" target="_blank"
+            6. <a href="https://www.cartoonnetwork.pl/filmy" target="_blank"
                 style="color:#A9A9A9;">CartoonNetwork.pl</a></br>
-            8. <a href="https://www.cda.pl/_WasylllOne_Bajaka_/folder-glowny" target="_blank"
+            7. <a href="https://www.cda.pl/_WasylllOne_Bajaka_/folder-glowny" target="_blank"
                 style="color:#A9A9A9;">CDA/_WasylllOne_Bajaka_</a> (hasło: 951)</br>
 
         </div>
@@ -1148,8 +1148,8 @@
                 style="color:#A9A9A9;">WorldCupFootball.me</a><br>
             24. <a href="http://720pstream.tv/" target="_blank" style="color:#A9A9A9;">720pStream.tv</a><br>
             25. <a href="https://footybite.com/" target="_blank" style="color:#A9A9A9;">FootyBite.com</a><br>
-            26. <a href="https://www.fullmatchesandshows.com/" target="_blank"
-                style="color:#A9A9A9;">FullMatchesAndShows.com</a><br>
+            26. <a href="https://soccercatch.com/" target="_blank"
+                style="color:#A9A9A9;">SoccerCatch.com</a><br>
             27. <a href="https://www.okgoals.com/index.php" target="_blank" style="color:#A9A9A9;">OKgoals.com</a><br>
             28. <a href="https://hoofoot.com/" target="_blank" style="color:#A9A9A9;">HooFoot.com</a><br>
             29. <a href="https://fullmatchtv.com/" target="_blank" style="color:#A9A9A9;">FullMatchTV.com</a><br>
@@ -1160,9 +1160,7 @@
             33. <a href="https://dreamsports.tv/" target="_blank" style="color:#A9A9A9;">DreamSports.tv</a><br>
             34. <a href="http://watchwrestling.la/" target="_blank" style="color:#A9A9A9;">WatchWrestling.la</a><br>
             35. <a href="http://www.hesgoal.com/" target="_blank" style="color:#A9A9A9;">HesGoal.com</a><br>
-            36. <a href="http://www.wiz1.net/" target="_blank" style="color:#A9A9A9;">Wiz1.net</a><br>
-            37. <a href="https://www.vipleague.cc/" target="_blank" style="color:#A9A9A9;">VipLeague.cc</a><br>
-            38. <a href="http://livetv.unblckd.pw/enx/" target="_blank" style="color:#A9A9A9;">LiveTV.unblckd.pw</a><br>
+            36. <a href="https://www.vipleague.cc/" target="_blank" style="color:#A9A9A9;">VipLeague.cc</a><br>
 
         </div>
     </div>
@@ -1216,12 +1214,12 @@
                 style="color:#A9A9A9;">OpenCulture.com</a><br>
             3. <a href="https://xaudiobooks.com/" target="_blank" style="color:#A9A9A9;">xAudioBooks.com</a><br>
             3. <a href="https://tokybook.com/" target="_blank" style="color:#A9A9A9;">TokyBook.com</a><br>
-            4. <a href="https://the-eye.eu/public/AudioBooks/Unsorted/" target="_blank"
-                style="color:#A9A9A9;">The-Eye.eu</a><br>
-            5. <a href="https://hotaudiobooks.com/" target="_blank" style="color:#A9A9A9;">HotAudioBooks.com</a><br>
-            6. <a href="https://goldenaudiobooks.com/" target="_blank"
+            <!-- 4. <a href="https://the-eye.eu/public/AudioBooks/Unsorted/" target="_blank"
+                style="color:#A9A9A9;">The-Eye.eu</a><br> -->
+            4. <a href="https://hotaudiobooks.com/" target="_blank" style="color:#A9A9A9;">HotAudioBooks.com</a><br>
+            5. <a href="https://goldenaudiobooks.com/" target="_blank"
                 style="color:#A9A9A9;">GoldenAudioBooks.com</a><br>
-            7. <a href="https://appaudiobooks.com/" target="_blank" style="color:#A9A9A9;">AppAudioBooks.com</a><br>
+            6. <a href="https://appaudiobooks.com/" target="_blank" style="color:#A9A9A9;">AppAudioBooks.com</a><br>
             <br>
             <b style="color: #C0C0C0; font-size: 25px">                
                 Lista darmowych stron z eBookami (Polskie i zagraniczne):</b>


### PR DESCRIPTION
1. CookMeFlix.xyz - strona nie ma już zawartości. #sbfilmynarzedzia
2. CDA/Cinek0002 - błędne hasło, materiały usunięte z konta. #sbbajki
3. LiveTV.unblckd.pw - duplikat. #sbsport
4. Wiz1.net - przestała działać. #sbsport
5. The-Eye.eu/AudioBooks - katalog usunięty. #sbksiazki